### PR TITLE
Add docker run options to increase memory access

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,17 +110,17 @@ Note: our latest image was built with CUDA 11.7.
 
 #### Run NeSVoR with Docker
 
-You may run a container in an iterative way.
+You may run a container in an interactive way.
 
 ```
-docker run -it --gpus all junshenxu/nesvor
+docker run -it --gpus all --ipc=host junshenxu/nesvor
 nesvor -h
 ```
 
 You may also run the `nesvor` command directly as follows.
 
 ```
-docker run --rm --gpus all \
+docker run --rm --gpus all --ipc=host \
     -v <path-to-inputs>:/incoming:ro -v <path-to-outputs>:/outgoing:rw \
     junshenxu/nesvor \
     nesvor reconstruct \

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -29,14 +29,14 @@ You may run a container in an iterative way.
 
 .. code-block:: bash
 
-    docker run -it --gpus all junshenxu/nesvor:v-version-placeholder-
+    docker run -it --gpus all --ipc=host junshenxu/nesvor:v-version-placeholder-
     nesvor -h
 
 You may also run the ``nesvor`` command directly as follows.
 
 .. code-block:: bash
 
-    docker run --rm --gpus all \
+    docker run --rm --gpus all --ipc=host \
         -v <path-to-inputs>:/incoming:ro -v <path-to-outputs>:/outgoing:rw \
         junshenxu/nesvor:v-version-placeholder- \
         nesvor reconstruct \


### PR DESCRIPTION
It is recommended to run NVIDIA CUDA container using `--ipc=host` to ensure the container can see all of VRAM + RAM.

Reference: https://github.com/pytorch/pytorch#docker-image

